### PR TITLE
검색어가 2글자 이상일때의 예외케이스를 처리합니다.

### DIFF
--- a/src/components/search/SuggestionKeywordItem/SuggestionKeywordItem.jsx
+++ b/src/components/search/SuggestionKeywordItem/SuggestionKeywordItem.jsx
@@ -11,7 +11,8 @@ const boldText = (suggestedKeyword, searchKeyword) => {
   const searchKeywordIndex = lowerCaseSuggestKeyword.indexOf(searchKeyword);
   const prevStrOfSearchKeyword = suggestedKeyword.slice(0, searchKeywordIndex);
   const nextStrOfSearchKeyword = suggestedKeyword.slice(searchKeywordIndex + searchKeyword.length);
-  return { prevStrOfSearchKeyword, nextStrOfSearchKeyword, searchKeywordIndex };
+
+  return { prevStrOfSearchKeyword, nextStrOfSearchKeyword };
 };
 
 const SuggestionKeywordItem = ({
@@ -22,7 +23,7 @@ const SuggestionKeywordItem = ({
   selected,
   hasText,
 }) => {
-  const { prevStrOfSearchKeyword, nextStrOfSearchKeyword, searchKeywordIndex } = boldText(
+  const { prevStrOfSearchKeyword, nextStrOfSearchKeyword } = boldText(
     suggestedKeyword,
     searchKeyword
   );
@@ -50,7 +51,7 @@ const SuggestionKeywordItem = ({
               </Styled.IconWarraper>
               {prevStrOfSearchKeyword}
               <Styled.SearchKeywordHighlight>
-                {suggestedKeyword[searchKeywordIndex]}
+                {searchKeyword.toUpperCase()}
               </Styled.SearchKeywordHighlight>
               {nextStrOfSearchKeyword}
             </>


### PR DESCRIPTION
## 변경사항

- 알파벳 한글자 검색시를 위하여 검색어 index를 구하여 추천 검색어 중 사용자가 입력한 검색어를 하이라이팅 해주었는데 (`suggestedKeyword[searchKeyword]`) 검색어가 2글자 이상일때 예외케이스가 발생하여 임시로 searchKeyword 자체를 upperCase하여 렌더링하는 방식으로 수정하였습니다.
